### PR TITLE
Rename links from funcx-faas GitHub org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Install `scriv` and `pre-commit` with
 ## Bugs & Feature Requests
 
 Should be reported as
-[GitHub Issues](https://github.com/funcx-faas/funcx-common/issues)
+[GitHub Issues](https://github.com/globus/globus-compute-common/issues)
 
 For a good bug report:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/funcx-faas/funcx-common/main.svg)](https://results.pre-commit.ci/latest/github/funcx-faas/funcx-common/main)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/globus/globus-compute-common/main.svg)](https://results.pre-commit.ci/latest/github/globus/globus-compute-common/main)
 
 # globus-compute-common
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,4 +18,4 @@ requirements mentioned in the [contrib doc](./CONTRIBUTING.md):
 2. Update changelog: `make prepare-release`
 3. Commit: `git commit -m 'Bump version and changelog for release'`
 4. Tag and publish release: `make release`
-5. Write up the release as a [globus-compute-common GitHub Release](https://github.com/funcx-faas/funcx-common/releases)
+5. Write up the release as a [globus-compute-common GitHub Release](https://github.com/globus/globus-compute-common/releases)

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ version = 0.4.1
 description = Common tools for Globus Compute projects
 long_description = file: README.md
 long_description_content_type = text/markdown
-url = https://github.com/funcX-faas/funcx-common
+url = https://github.com/globus/globus-compute-common
 author = Globus Team
 author_email = support@globus.org
 


### PR DESCRIPTION
Update our codebase to match the new repo URLs